### PR TITLE
Upgrading carbon-apimgt dependencies to support APIM 4.2.0

### DIFF
--- a/components/okta.key.manager/pom.xml
+++ b/components/okta.key.manager/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.km.ext.okta</groupId>
         <artifactId>okta.auth.client</artifactId>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>okta.key.manager</artifactId>

--- a/features/okta.key.manager.feature/pom.xml
+++ b/features/okta.key.manager.feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.wso2.km.ext.okta</groupId>
         <artifactId>okta.auth.client</artifactId>
-        <version>3.1.2-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     </scm>
 
     <properties>
-        <carbon.apimgt.version>9.26.39</carbon.apimgt.version>
+        <carbon.apimgt.version>9.27.0</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[6.7.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
         <json.simple.version>1.1</json.simple.version>
         <gson.version>2.1</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.km.ext.okta</groupId>
     <artifactId>okta.auth.client</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <parent>
         <groupId>org.wso2</groupId>
@@ -181,7 +181,7 @@
     </scm>
 
     <properties>
-        <carbon.apimgt.version>9.20.34</carbon.apimgt.version>
+        <carbon.apimgt.version>9.26.39</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[6.7.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
         <json.simple.version>1.1</json.simple.version>
         <gson.version>2.1</gson.version>


### PR DESCRIPTION
## Purpose
Upgrade carbon-apimgt dependencies to support APIM 4.2.0

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/11628